### PR TITLE
Fixed Infinite loop in the questionBank.txt parsing

### DIFF
--- a/questionBank.txt
+++ b/questionBank.txt
@@ -23,13 +23,13 @@ PG4
 (F)
 $
 ? True or False: Giving a designation of private allows for use of method or value in its own class.
-PDF 
+PDF
 PG4
 (T)<
 (F)
 $
 ? True or False: A protected value or method can only be accessed by another class in the same package or a subclass.
-PDF 
+PDF
 PG4
 (T)<
 (F)
@@ -41,7 +41,8 @@ PG4
 (B) Class, and Package
 (C) Class, Subclass, and Package<
 (D) Subclass, and Package
-$ A access level of a public modifier will have access to:
+$
+? A access level of a public modifier will have access to:
 PDF
 PG4
 (A) Class

--- a/src/proctortest/QuestionParser.java
+++ b/src/proctortest/QuestionParser.java
@@ -93,6 +93,10 @@ public class QuestionParser {
 
                 // Uses the length to test for '$'
                 // If line from file is not $ -> add line to components array list, prepare for building each question
+              
+                // TODO Brandon: This could cause some hard to debug runtime errors (Like the infinite that was caused just now) if the questionBank.txt isn't 
+                // formatted exactly how it should be. For example if there is a space after $ or really any type of 
+                // character it can fail. Would suggest changing this to looking for a $ in the string.
                 if (lineFromFile.length() > 1) {
                     components.add(lineFromFile); // Add line to the components array list
                 }


### PR DESCRIPTION
This was caused by how the question bank was finding the end of a question block.
Right now it is looking for any line that has under 1 elements, which will definitely
work if the questionBank.txt is formatted exactly how it should be, but we are all human
so simple things like a space character can slip past us (As in this case).

I left the parsing code the same for now but will make changes in a bit to instead
maybe just search that string for a $ character.